### PR TITLE
refactoring | #134 | change logic to get project deps

### DIFF
--- a/packages/@react-cli-ui/cli-ui/server/connectors/dependencies.js
+++ b/packages/@react-cli-ui/cli-ui/server/connectors/dependencies.js
@@ -14,10 +14,13 @@ class DependenciesApi extends StaticMethods {
     this.dependencies = []
   }
 
-  list (file) {
-    const filePath = `/${file.join('/')}`
+  list () {
+    const activeProjectId = this.db.get('config.lastOpenProject').value()
+    const activeProject = this.db.get('projects').find({ id: activeProjectId }).value()
+
+    const filePath = `/${activeProject.path.join('/')}`
     const pkg = this.readPackage(path.join(filePath))
-   
+
     if (pkg) {
       this.dependencies = this.dependencies.concat(
         this.findDependencies(pkg.devDependencies || {}, 'devDependencies', filePath)

--- a/packages/@react-cli-ui/cli-ui/server/connectors/index.js
+++ b/packages/@react-cli-ui/cli-ui/server/connectors/index.js
@@ -74,17 +74,17 @@ function api (message, client) {
         project.clearDb()
         break
 
-        // Dependencies
+      // Dependencies
       case 'GET_LIST_DEPENDINCIES':
         dependencies.list(path)
         break
 
-        // Config
+      // Config
       case 'GET_CONFIG':
         project.getConfig()
         break
 
-        // Logs
+      // Logs
       case 'GET_LOGS':
         logs.list()
         break

--- a/packages/@react-cli-ui/cli-ui/server/connectors/projects.js
+++ b/packages/@react-cli-ui/cli-ui/server/connectors/projects.js
@@ -50,8 +50,11 @@ class ProjectApi extends StaticMethods {
       this.db.get('projects')
         .value()
         .forEach((project) => {
-          if (!fs.existsSync(path.join('/', ...project.path.slice(0,-1), project.name))) {
+          if (!fs.existsSync(path.join('/', ...project.path.slice(0, -1), project.name))) {
             this.db.get('projects').remove({ id: project.id }).write()
+            if (this.db.get('config.lastOpenProject').value() === project.id) {
+              this.db.set('config', {}).write()
+            }
           }
         })
       this.client.emit('projects', {

--- a/packages/@react-cli-ui/cli-ui/server/connectors/utils.js
+++ b/packages/@react-cli-ui/cli-ui/server/connectors/utils.js
@@ -43,7 +43,6 @@ class StaticMethods {
 
   readPackage (file) {
     const pkgFile = path.join(file, 'package.json')
-    console.log("pkgFile", pkgFile)
     if (fs.existsSync(pkgFile)) {
       const pkg = fs.readJsonSync(pkgFile)
       return pkg

--- a/packages/@react-cli-ui/cli-ui/src/components/Dependencies/ProjectDependencies.tsx
+++ b/packages/@react-cli-ui/cli-ui/src/components/Dependencies/ProjectDependencies.tsx
@@ -17,26 +17,26 @@ interface PropsDepend {
   list: PropsItem[];
 }
 
-export default function ProjectDependencies ({list}: PropsDepend) {
+export default function ProjectDependencies ({ list }: PropsDepend) {
   const { t } = useTranslation('dependencies')
 
-  const listDepend = list.filter(p => p.type === "dependencies")
-  const listDevDepend = list.filter(p => p.type === "devDependencies")
+  const listDepend = list.filter(p => p.type === 'dependencies')
+  const listDevDepend = list.filter(p => p.type === 'devDependencies')
 
   return (
     <div className={css.wrapper}>
       {!!listDepend.length && <div className={css.title}>{t('main')}</div>}
       {listDepend.map(dep => (
-        <ProjectDependencyItem 
-         key={dep.id}
-         {...dep}
+        <ProjectDependencyItem
+          key={dep.id}
+          {...dep}
         />
       ))}
       {!!listDevDepend.length && <div>{t('dev')}</div>}
       {listDevDepend.map(dep => (
         <ProjectDependencyItem
-         key={dep.id}
-         {...dep}
+          key={dep.id}
+          {...dep}
         />
       ))}
     </div>

--- a/packages/@react-cli-ui/cli-ui/src/components/Dependencies/ProjectDependencyItem.tsx
+++ b/packages/@react-cli-ui/cli-ui/src/components/Dependencies/ProjectDependencyItem.tsx
@@ -28,12 +28,12 @@ export default function ProjectDependencyItem (item: PropsItem) {
             {t('version')}: {item.versionRange}
           </div>
           <div className={css.info}>
-           { item.installed 
-              ? <div className={css.like}><LikeIcon /> {t('installed')}</div> 
+            { item.installed
+              ? <div className={css.like}><LikeIcon /> {t('installed')}</div>
               : <div>{t('noInstalled')}</div>}
           </div>
           <div className={css.info}>
-            <a href={item.website} target="_blank">
+            <a href={item.website} target="_blank" rel="noreferrer">
               <LinkIcon/> {t('moreInfo')}
             </a>
           </div>

--- a/packages/@react-cli-ui/cli-ui/src/pages/Dependencies.tsx
+++ b/packages/@react-cli-ui/cli-ui/src/pages/Dependencies.tsx
@@ -5,17 +5,15 @@ import { SettingsContext } from '../context'
 
 export default function Dependencies () {
   const { t } = useTranslation('dashboard')
-  const { socket, selectedPath } = useContext(SettingsContext)
+  const { socket } = useContext(SettingsContext)
   const [dependencies, setDependencies] = useState([])
 
   useEffect(() => {
-
     socket.send({
-      type: 'GET_LIST_DEPENDINCIES',
-      path: selectedPath
+      type: 'GET_LIST_DEPENDINCIES'
     })
 
-    socket.on('dependencies', (res) => {
+    socket.on('dependencies', (res: any) => {
       setDependencies(res.data)
     })
 


### PR DESCRIPTION
**EN**

> Refactor the functionality of getting dependencies of the active project.
> Remove transfer from the frontend to the backend of the path on which the project is located.
> Use the id that is stored in the database.

**RU**

> Отрефакторить функционал получения зависимостей активного проекта.
> Удалить передачу с фронтенда на бекенд пути по которому находится проект.
> Использовать id который сохранен в базе данных.

Closes #134 